### PR TITLE
Auto register a user who's a member of another org

### DIFF
--- a/util/createUserProfile.ts
+++ b/util/createUserProfile.ts
@@ -1,0 +1,34 @@
+import type { definitions } from '../@types/supabase'
+import { createClient } from '@supabase/supabase-js'
+
+type UserProfile = definitions['squeak_profiles']
+
+interface Result {
+    data?: UserProfile
+    error?: Error
+}
+
+const createUserProfile = async (first_name?: string, last_name?: string, avatar?: string): Promise<Result> => {
+    const supabaseServiceRoleClient = createClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+        process.env.SUPABASE_SERVICE_ROLE_KEY as string
+    )
+
+    const { data, error } = await supabaseServiceRoleClient
+        .from<UserProfile>('squeak_profiles')
+        .insert({
+            first_name: first_name,
+            last_name: last_name,
+            avatar,
+        })
+        .limit(1)
+        .single()
+
+    if (!data || error) {
+        return { error: new Error(error?.message ?? 'Failed to create profile') }
+    }
+
+    return { data }
+}
+
+export default createUserProfile

--- a/util/createUserProfileReadonly.ts
+++ b/util/createUserProfileReadonly.ts
@@ -1,0 +1,41 @@
+import type { definitions } from '../@types/supabase'
+import { createClient } from '@supabase/supabase-js'
+
+type UserProfileReadonly = definitions['squeak_profiles_readonly']
+
+interface Result {
+    data?: UserProfileReadonly
+    error?: Error
+}
+
+const createUserProfileReadonly = async (
+    userId: string,
+    organizationId: string,
+    profileId: string,
+    role = 'user'
+): Promise<Result> => {
+    const supabaseServiceRoleClient = createClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+        process.env.SUPABASE_SERVICE_ROLE_KEY as string
+    )
+
+    // Create readonly profile
+    const { data, error } = await supabaseServiceRoleClient
+        .from<UserProfileReadonly>('squeak_profiles_readonly')
+        .insert({
+            role,
+            user_id: userId,
+            organization_id: organizationId,
+            profile_id: profileId,
+        })
+        .limit(1)
+        .single()
+
+    if (!data || error) {
+        return { error: new Error(error?.message ?? 'Failed to create readonly profile') }
+    }
+
+    return { data }
+}
+
+export default createUserProfileReadonly

--- a/util/getUserProfile.ts
+++ b/util/getUserProfile.ts
@@ -3,6 +3,8 @@ import type { GetServerSidePropsContext, NextApiResponse } from 'next'
 import { supabaseServerClient } from '@supabase/supabase-auth-helpers/nextjs'
 import { definitions } from '../@types/supabase'
 import { NextApiRequest } from 'next'
+import createUserProfile from './createUserProfile'
+import createUserProfileReadonly from './createUserProfileReadonly'
 
 type UserProfile = definitions['squeak_profiles']
 type UserProfileReadonly = definitions['squeak_profiles_readonly']
@@ -33,16 +35,54 @@ const lookupUserProfile = async (context: Context, user: User, organizationId: s
         .eq('user_id', user.id)
         .eq('organization_id', organizationId)
         .limit(1)
-        .single()
 
     if (userProfileReadonlyError) {
         return { error: new Error(userProfileReadonlyError.message) }
     }
 
+    // If the user does not have a profile, they likely have one for another org, but not this one, so we'll create one
+    // for this org.
+    if (!userProfileReadonly || userProfileReadonly.length === 0) {
+        // Get an existing profile from another org
+        const { data: existingProfile, error: existingProfileError } = await supabaseServerClient(context)
+            .from('squeak_profiles_readonly')
+            .select('id, profile:squeak_profiles(first_name, last_name)')
+            .limit(1)
+            .single()
+
+        if (!existingProfile || existingProfileError) {
+            return { error: new Error(existingProfileError?.message ?? 'User has no profile in any organization') }
+        }
+
+        // Create profile
+        const { data: createdProfile, error: createdProfileError } = await createUserProfile(
+            existingProfile.profile.first_name,
+            existingProfile.profile.last_name
+        )
+
+        if (!createdProfile || createdProfileError) {
+            return { error: new Error(createdProfileError?.message ?? 'Failed to create profile') }
+        }
+
+        const { data: createdProfileReadonly, error: createdProfileReadonlyError } = await createUserProfileReadonly(
+            user.id,
+            organizationId,
+            createdProfile.id,
+            'user'
+        )
+
+        if (!createdProfileReadonly || createdProfileReadonlyError) {
+            return { error: new Error(createdProfileReadonlyError?.message ?? 'Failed to create readonly profile') }
+        }
+
+        return { data: createdProfile }
+    }
+
+    const [{ profile_id }] = userProfileReadonly
     const { data: userProfile, error: userProfileError } = await supabaseServerClient(context)
         .from<UserProfile>('squeak_profiles')
         .select('*')
-        .eq('id', userProfileReadonly?.profile_id)
+        .eq('id', profile_id)
         .limit(1)
         .single()
 


### PR DESCRIPTION
Supabase Auth is central (on a basis of 1-1 for each user across multiple orgs), we have a 1-N basis for user-profiles.

This means if a user signs up for Org A, they get a profile row (and a user account in supabase), they can then use that same  user account to login to Org B, but they would not have a profile row.

This solves that, giving them a profile row for Org B if they interact with it (question, reply etc)