### PR TITLE
Pass path name to redirectTo

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,11 +1,11 @@
 import { supabaseClient } from '@supabase/supabase-auth-helpers/nextjs'
-import Router from 'next/router'
-import Link from 'next/link'
-import { ReactElement, useEffect, useState } from 'react'
-import LoginLayout from '../layout/LoginLayout'
-import type { NextPageWithLayout } from '../@types/types'
 import { GetStaticPropsResult } from 'next'
+import Link from 'next/link'
+import Router from 'next/router'
+import { ReactElement, useEffect, useState } from 'react'
+import type { NextPageWithLayout } from '../@types/types'
 import useActiveOrganization from '../hooks/useActiveOrganization'
+import LoginLayout from '../layout/LoginLayout'
 
 interface Props {
     isMultiTenancy: boolean
@@ -24,7 +24,7 @@ const Login: NextPageWithLayout<Props> = () => {
                 // Timeout required to allow for the cookie to be set before redirecting
                 // TODO(JS): There must be a better way to do this?
                 setTimeout(() => {
-                    Router.push('/')
+                    Router.push(Router.query?.redirect ? Router.query?.redirect + '' : '/')
                 }, 1000)
             }
         })

--- a/pages/profiles.tsx
+++ b/pages/profiles.tsx
@@ -1,12 +1,12 @@
 import { supabaseClient } from '@supabase/supabase-auth-helpers/nextjs'
 import { GetStaticPropsResult } from 'next'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
+import { useToasts } from 'react-toast-notifications'
 import { definitions } from '../@types/supabase'
 import { NextPageWithLayout } from '../@types/types'
 import InviteUser from '../components/InviteUser'
-import useActiveOrganization from '../hooks/useActiveOrganization'
-import { useToasts } from 'react-toast-notifications'
 import ProfileTable from '../components/ProfileTable'
+import useActiveOrganization from '../hooks/useActiveOrganization'
 import AdminLayout from '../layout/AdminLayout'
 import withAdminAccess from '../util/withAdminAccess'
 
@@ -71,7 +71,7 @@ Users.getLayout = function getLayout(page: ReactElement) {
 }
 
 export const getServerSideProps = withAdminAccess({
-    redirectTo: '/login',
+    redirectTo: () => '/login',
     async getServerSideProps(): Promise<GetStaticPropsResult<Props>> {
         return {
             props: {},

--- a/pages/question/[id].js
+++ b/pages/question/[id].js
@@ -3,11 +3,11 @@ import { useUser } from '@supabase/supabase-auth-helpers/react'
 import dynamic from 'next/dynamic'
 import { useState } from 'react'
 import EditQuestion from '../../components/question/EditQuestion'
+import SlugTable from '../../components/question/SlugTable'
 import AdminLayout from '../../layout/AdminLayout'
 import getActiveOrganization from '../../util/getActiveOrganization'
 import getQuestion from '../../util/getQuestion'
 import withAdminAccess from '../../util/withAdminAccess'
-import SlugTable from '../../components/question/SlugTable'
 const SingleQuestion = dynamic(() => import('squeak-react').then((mod) => mod.Question), { ssr: false })
 
 const Question = ({ question: initialQuestion, organizationId }) => {
@@ -72,7 +72,7 @@ Question.getLayout = function getLayout(page) {
 }
 
 export const getServerSideProps = withAdminAccess({
-    redirectTo: '/login',
+    redirectTo: (url) => `/login?redirect=${url}`,
     async getServerSideProps(context) {
         const { id } = context.query
 

--- a/pages/questions.tsx
+++ b/pages/questions.tsx
@@ -166,17 +166,14 @@ const Questions: NextPageWithLayout<Props> = ({ results, start, domain }) => {
 
 Questions.getLayout = function getLayout(page) {
     return (
-        <AdminLayout
-            hideTitle
-            title={'Questions'}
-        >
+        <AdminLayout hideTitle title={'Questions'}>
             {page}
         </AdminLayout>
     )
 }
 
 export const getServerSideProps = withAdminAccess({
-    redirectTo: '/login',
+    redirectTo: () => '/login',
     async getServerSideProps(context) {
         const organizationId = await getActiveOrganization(context)
         const start = context.query?.start ? parseInt(context.query?.start as string) : 0

--- a/pages/reset-password.tsx
+++ b/pages/reset-password.tsx
@@ -22,7 +22,7 @@ Reset.getLayout = function getLayout(page: ReactElement) {
 }
 
 export const getServerSideProps = withAdminAccess({
-    redirectTo: '/login',
+    redirectTo: () => '/login',
 })
 
 export default Reset

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -217,7 +217,7 @@ Settings.getLayout = function getLayout(page: ReactElement) {
 }
 
 export const getServerSideProps = withAdminAccess({
-    redirectTo: '/login',
+    redirectTo: () => '/login',
     async getServerSideProps(context): Promise<GetStaticPropsResult<Props>> {
         const organizationId = getActiveOrganization(context)
 

--- a/pages/slack.tsx
+++ b/pages/slack.tsx
@@ -397,7 +397,7 @@ Slack.getLayout = function getLayout(page: ReactElement) {
 }
 
 export const getServerSideProps = withAdminAccess({
-    redirectTo: '/login',
+    redirectTo: () => '/login',
     async getServerSideProps() {
         return {
             props: {},

--- a/util/sendQuestionAlert.ts
+++ b/util/sendQuestionAlert.ts
@@ -75,6 +75,13 @@ const sendQuestionAlert = async (
                                                 },
                                             }),
                                         },
+                                        {
+                                            type: 'section',
+                                            text: {
+                                                type: 'mrkdwn',
+                                                text: `<https://squeak.cloud/question/${messageId}|View question>`,
+                                            },
+                                        },
                                     ],
                                 }),
                             })

--- a/util/withAdminAccess.ts
+++ b/util/withAdminAccess.ts
@@ -1,9 +1,13 @@
-import type { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from 'next'
-
 import { getUser, supabaseServerClient } from '@supabase/supabase-auth-helpers/nextjs'
-import { definitions } from '../@types/supabase'
 import { createClient } from '@supabase/supabase-js'
-import type { GetServerSideProps, NextApiHandler } from 'next'
+import type {
+    GetServerSideProps,
+    GetServerSidePropsContext,
+    NextApiHandler,
+    NextApiRequest,
+    NextApiResponse,
+} from 'next'
+import { definitions } from '../@types/supabase'
 import getActiveOrganization from './getActiveOrganization'
 
 type Config = definitions['squeak_config']
@@ -11,7 +15,7 @@ type UserReadonlyProfile = definitions['squeak_profiles_readonly']
 
 type Args =
     | {
-          redirectTo?: string
+          redirectTo?: (url: string) => string
           getServerSideProps?: GetServerSideProps
       }
     | NextApiHandler
@@ -87,7 +91,7 @@ const withAdminAccess = (arg: Args) => {
                 if (!user) {
                     return {
                         redirect: {
-                            destination: arg.redirectTo,
+                            destination: arg.redirectTo && arg.redirectTo(context.resolvedUrl),
                             permanent: false,
                         },
                     }
@@ -104,7 +108,7 @@ const withAdminAccess = (arg: Args) => {
                 if (!userReadonlyProfile) {
                     return {
                         redirect: {
-                            destination: arg.redirectTo,
+                            destination: arg.redirectTo && arg.redirectTo(context.resolvedUrl),
                             permanent: false,
                         },
                     }
@@ -131,7 +135,7 @@ const withAdminAccess = (arg: Args) => {
             } catch (error) {
                 return {
                     redirect: {
-                        destination: arg.redirectTo,
+                        destination: arg.redirectTo && arg.redirectTo(context.resolvedUrl),
                         permanent: false,
                     },
                 }


### PR DESCRIPTION
- Turns `redirectTo` into a function that passes the current pathname
- Uses new pathname arg on `/login` to redirect to the original page after logged in
- Adds view question link to Slack notification