### PR TITLE
Add Mailgun from name and email fields

### DIFF
--- a/@types/supabase.d.ts
+++ b/@types/supabase.d.ts
@@ -123,6 +123,8 @@ export interface paths {
           allowed_origins?: parameters["rowFilter.squeak_config.allowed_origins"];
           reply_auto_publish?: parameters["rowFilter.squeak_config.reply_auto_publish"];
           show_slack_user_profiles?: parameters["rowFilter.squeak_config.show_slack_user_profiles"];
+          mailgun_from_name?: parameters["rowFilter.squeak_config.mailgun_from_name"];
+          mailgun_from_email?: parameters["rowFilter.squeak_config.mailgun_from_email"];
           /** Filtering Columns */
           select?: parameters["select"];
           /** Ordering */
@@ -187,6 +189,8 @@ export interface paths {
           allowed_origins?: parameters["rowFilter.squeak_config.allowed_origins"];
           reply_auto_publish?: parameters["rowFilter.squeak_config.reply_auto_publish"];
           show_slack_user_profiles?: parameters["rowFilter.squeak_config.show_slack_user_profiles"];
+          mailgun_from_name?: parameters["rowFilter.squeak_config.mailgun_from_name"];
+          mailgun_from_email?: parameters["rowFilter.squeak_config.mailgun_from_email"];
         };
         header: {
           /** Preference */
@@ -215,6 +219,8 @@ export interface paths {
           allowed_origins?: parameters["rowFilter.squeak_config.allowed_origins"];
           reply_auto_publish?: parameters["rowFilter.squeak_config.reply_auto_publish"];
           show_slack_user_profiles?: parameters["rowFilter.squeak_config.show_slack_user_profiles"];
+          mailgun_from_name?: parameters["rowFilter.squeak_config.mailgun_from_name"];
+          mailgun_from_email?: parameters["rowFilter.squeak_config.mailgun_from_email"];
         };
         body: {
           /** squeak_config */
@@ -1142,6 +1148,10 @@ export interface definitions {
     reply_auto_publish: boolean;
     /** Format: boolean */
     show_slack_user_profiles: boolean;
+    /** Format: text */
+    mailgun_from_name?: string;
+    /** Format: text */
+    mailgun_from_email?: string;
   };
   squeak_messages: {
     /**
@@ -1475,6 +1485,10 @@ export interface parameters {
   "rowFilter.squeak_config.reply_auto_publish": string;
   /** Format: boolean */
   "rowFilter.squeak_config.show_slack_user_profiles": string;
+  /** Format: text */
+  "rowFilter.squeak_config.mailgun_from_name": string;
+  /** Format: text */
+  "rowFilter.squeak_config.mailgun_from_email": string;
   /** @description squeak_messages */
   "body.squeak_messages": definitions["squeak_messages"];
   /** Format: bigint */

--- a/components/NotificationForm.tsx
+++ b/components/NotificationForm.tsx
@@ -12,6 +12,8 @@ type Config = definitions['squeak_config']
 interface Props {
     mailgunApiKey: string
     mailgunDomain: string
+    mailgunName: string
+    mailgunEmail: string
     redirect?: string
     actionButtons: (isValid: boolean, loading: boolean) => JSX.Element
 }
@@ -19,11 +21,15 @@ interface Props {
 interface InitialValues {
     mailgunApiKey: string
     mailgunDomain: string
+    mailgunName: string
+    mailgunEmail: string
 }
 
 const NotificationForm: React.VoidFunctionComponent<Props> = ({
     mailgunApiKey,
     mailgunDomain,
+    mailgunName,
+    mailgunEmail,
     redirect,
     actionButtons,
 }) => {
@@ -40,6 +46,8 @@ const NotificationForm: React.VoidFunctionComponent<Props> = ({
             .update({
                 mailgun_api_key: values.mailgunApiKey,
                 mailgun_domain: values.mailgunDomain,
+                mailgun_from_email: values.mailgunEmail,
+                mailgun_from_name: values.mailgunName,
             })
             .match({ organization_id: organizationId })
 
@@ -57,6 +65,8 @@ const NotificationForm: React.VoidFunctionComponent<Props> = ({
     const initialValues: InitialValues = {
         mailgunApiKey: mailgunApiKey,
         mailgunDomain: mailgunDomain,
+        mailgunName: mailgunName,
+        mailgunEmail: mailgunEmail,
     }
 
     return (
@@ -77,6 +87,18 @@ const NotificationForm: React.VoidFunctionComponent<Props> = ({
                             name="mailgunDomain"
                             placeholder="Mailgun domain"
                             helperText="Choose the sending domain from Sending → Domains"
+                        />
+                        <Input
+                            label="Mailgun from name"
+                            id="mailgunName"
+                            name="mailgunName"
+                            placeholder="Mailgun from name"
+                        />
+                        <Input
+                            label="Mailgun from email"
+                            id="mailgunEmail"
+                            name="mailgunEmail"
+                            placeholder="Mailgun from email"
                         />
                         <div className="flex space-x-6 items-center mt-4">{actionButtons(isValid, loading)}</div>
                     </Form>

--- a/components/SQLSnippet.js
+++ b/components/SQLSnippet.js
@@ -6,6 +6,8 @@ export const sql = `CREATE TABLE public.squeak_config (
     slack_signing_secret text,
     mailgun_api_key text,
     mailgun_domain text,
+    mailgun_from_name text,
+    mailgun_from_email text,
     company_name text,
     company_domain text,
     organization_id uuid NOT NULL,

--- a/migrations/1652143747569_mailgun-from-config.js
+++ b/migrations/1652143747569_mailgun-from-config.js
@@ -1,0 +1,24 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined
+
+exports.up = (pgm) => {
+    pgm.addColumns(
+        { schema: 'public', name: 'squeak_config' },
+        {
+            mailgun_from_name: {
+                type: 'text',
+                default: null,
+            },
+        }
+    )
+    pgm.addColumns(
+        { schema: 'public', name: 'squeak_config' },
+        {
+            mailgun_from_email: {
+                type: 'text',
+                default: null,
+            },
+        }
+    )
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -25,6 +25,8 @@ type Config = definitions['squeak_config']
 interface Props {
     mailgunApiKey: string
     mailgunDomain: string
+    mailgunName: string
+    mailgunEmail: string
     companyName: string
     companyDomain: string
     slackApiKey: string
@@ -37,6 +39,8 @@ interface Props {
 const Settings: NextPageWithLayout<Props> = ({
     mailgunApiKey,
     mailgunDomain,
+    mailgunName,
+    mailgunEmail,
     companyName,
     companyDomain,
     slackApiKey,
@@ -157,6 +161,8 @@ const Settings: NextPageWithLayout<Props> = ({
                 <h3 className="font-bold">Email notifications</h3>
                 <p>Configure emails for users when someone answers their question.</p>
                 <NotificationForm
+                    mailgunName={mailgunName}
+                    mailgunEmail={mailgunEmail}
                     mailgunDomain={mailgunDomain}
                     mailgunApiKey={mailgunApiKey}
                     actionButtons={(isValid, loading) => (
@@ -224,7 +230,7 @@ export const getServerSideProps = withAdminAccess({
         const { data: config } = await supabaseServerClient(context)
             .from<Config>('squeak_config')
             .select(
-                `mailgun_api_key, mailgun_domain, company_name, company_domain, slack_api_key, slack_question_channel, question_auto_publish, reply_auto_publish, show_slack_user_profiles`
+                `mailgun_api_key, mailgun_domain, mailgun_from_name, mailgun_from_email, company_name, company_domain, slack_api_key, slack_question_channel, question_auto_publish, reply_auto_publish, show_slack_user_profiles`
             )
             .eq('organization_id', organizationId)
             .single()
@@ -235,6 +241,8 @@ export const getServerSideProps = withAdminAccess({
             props: {
                 mailgunApiKey: config?.mailgun_api_key || '',
                 mailgunDomain: config?.mailgun_domain || '',
+                mailgunName: config?.mailgun_from_name || '',
+                mailgunEmail: config?.mailgun_from_email || '',
                 companyName: config?.company_name || '',
                 companyDomain: config?.company_domain || '',
                 slackApiKey: config?.slack_api_key || '',

--- a/pages/setup/notifications.tsx
+++ b/pages/setup/notifications.tsx
@@ -15,9 +15,11 @@ type Config = definitions['squeak_config']
 interface Props {
     mailgunApiKey: string
     mailgunDomain: string
+    mailgunName: string
+    mailgunEmail: string
 }
 
-const Notifications: NextPageWithLayout<Props> = ({ mailgunApiKey, mailgunDomain }) => {
+const Notifications: NextPageWithLayout<Props> = ({ mailgunApiKey, mailgunDomain, mailgunName, mailgunEmail }) => {
     const handleSkip = () => {
         Router.push('/setup/alerts')
     }
@@ -33,6 +35,8 @@ const Notifications: NextPageWithLayout<Props> = ({ mailgunApiKey, mailgunDomain
                 </p>
 
                 <NotificationForm
+                    mailgunName={mailgunName}
+                    mailgunEmail={mailgunEmail}
                     mailgunApiKey={mailgunApiKey}
                     mailgunDomain={mailgunDomain}
                     redirect="/setup/alerts"
@@ -73,7 +77,9 @@ export const getServerSideProps = withPreflightCheck({
 
         const { data: config } = await supabaseServerClient(context)
             .from<Config>('squeak_config')
-            .select(`mailgun_api_key, mailgun_domain, company_name, company_domain`)
+            .select(
+                `mailgun_api_key, mailgun_domain, mailgun_from_name, mailgun_from_email, company_name, company_domain`
+            )
             .eq('organization_id', organizationId)
             .single()
 
@@ -83,6 +89,8 @@ export const getServerSideProps = withPreflightCheck({
             props: {
                 mailgunApiKey: config?.mailgun_api_key || '',
                 mailgunDomain: config?.mailgun_domain || '',
+                mailgunName: config?.mailgun_from_name || '',
+                mailgunEmail: config?.mailgun_from_email || '',
             },
         }
     },

--- a/util/sendReplyNotification.ts
+++ b/util/sendReplyNotification.ts
@@ -20,7 +20,7 @@ const sendReplyNotification = async (organizationId: string, messageId: number, 
 
     const { data: config, error: configError } = await supabaseServiceUserClient
         .from<Config>('squeak_config')
-        .select(`mailgun_api_key, mailgun_domain, company_name, company_domain`)
+        .select(`mailgun_api_key, mailgun_domain, mailgun_from_name, mailgun_from_email, company_name, company_domain`)
         .eq('organization_id', organizationId)
         .limit(1)
         .single()
@@ -35,7 +35,8 @@ const sendReplyNotification = async (organizationId: string, messageId: number, 
         return
     }
 
-    const { company_name, company_domain, mailgun_api_key, mailgun_domain } = config
+    const { company_name, company_domain, mailgun_api_key, mailgun_domain, mailgun_from_name, mailgun_from_email } =
+        config
 
     if (!company_name || !company_domain || !mailgun_api_key || !mailgun_domain) {
         console.warn(`[📧 Mailgun] Mailgun credentials missing in config`)
@@ -130,7 +131,7 @@ const sendReplyNotification = async (organizationId: string, messageId: number, 
     const url = new URL(company_domain)
 
     const mailgunData = {
-        from: `${company_name} <noreply@${url.hostname}>`,
+        from: `${mailgun_from_name || company_name} <${mailgun_from_email || `noreply@${url.hostname}`}>`,
         to: email,
         subject: `Someone answered your question on ${company_domain}!`,
         html: `Hey,<br>Someone answered your question on <a href="${url.origin}${message.slug}">${url.origin}${message.slug}</a>!<br><br>Question:<br>${message.subject}<br>${question.body}<br><br>Reply:<br>${body}<br>Thanks,<br>${company_name}`,


### PR DESCRIPTION
- Adds new fields (from name, from email) to the notifications form. This will allow users to decide who the email is sent from. If no from name or from email are specified, it defaults to company name and company domain (like before).

This also solves the issue of PostHog’s notification emails displaying “via squeak.cloud” by giving us the ability to change the from email to [noreply@squeak.cloud](mailto:noreply@squeak.cloud).