### PR TITLE
Change protocol-relative API host URL to HTTPS

### DIFF
--- a/components/CodeSnippet.tsx
+++ b/components/CodeSnippet.tsx
@@ -20,7 +20,7 @@ const CodeSnippet: React.VoidFunctionComponent<Props> = ({ allQuestions, ...rest
             apiKey: "${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY}",
             url: "${process.env.NEXT_PUBLIC_SUPABASE_URL}",
         },
-        apiHost: "//${typeof window !== 'undefined' && window.location.host}",
+        apiHost: "https://${typeof window !== 'undefined' && window.location.host}",
         organizationId: "${organizationId}"${
         allQuestions
             ? `,


### PR DESCRIPTION
## Issue

Squeak cloud redirects all HTTP requests to HTTPS. Since we're using a protocol-relative URL in the snippet, if the user is using HTTP, their requests get redirected to HTTPS, causing the request to fail.

## Changes

- Changes protocol-relative API host URL to HTTPS