### PR TITLE
getQuestion requires and filters by organizationId

### DIFF
--- a/pages/question/[id].js
+++ b/pages/question/[id].js
@@ -27,7 +27,7 @@ const Question = ({ question: initialQuestion, organizationId }) => {
     }
 
     const handleSubmit = async () => {
-        const question = await getQuestion(id)
+        const question = await getQuestion(id, organizationId)
         setQuestion(question)
     }
 
@@ -84,7 +84,7 @@ export const getServerSideProps = withAdminAccess({
         }
 
         const organizationId = getActiveOrganization(context)
-        const question = await getQuestion(id)
+        const question = await getQuestion(id, organizationId)
 
         const {
             data: { company_domain },

--- a/util/getQuestion.ts
+++ b/util/getQuestion.ts
@@ -9,11 +9,12 @@ interface Response {
     replies: Array<Reply>
 }
 
-const getQuestion = async (id: string | number): Promise<Response> => {
+const getQuestion = async (id: string | number, organizationId: string): Promise<Response> => {
     const { data: question } = await supabaseClient
         .from<Question>('squeak_messages')
         .select('subject, id, slug, created_at, published, slack_timestamp, resolved, resolved_reply_id')
         .eq('id', id)
+        .eq('organization_id', organizationId)
         .limit(1)
         .single()
 


### PR DESCRIPTION
This makes the `getQuestion` supabase query filter by `organizationId`.

_Note: there may be a lingering issue whereby a clever user can inject an arbitrary `organizationId` into the query function, so ideally these queries should only be executed on the backend. I'm still relatively new to supabase, so I'm not sure the best practice for preventing this sort of thing from happening._