### PR TITLE
Logout, forgot password, cookie domain fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ FROM node:16-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV production
+ARG MAILGUN_API_KEY
+ENV MAILGUN_API_KEY=${MAILGUN_API_KEY}
 # Uncomment the following line in case you want to disable telemetry during runtime.
 # ENV NEXT_TELEMETRY_DISABLED 1
 

--- a/lib/auth/cookies.ts
+++ b/lib/auth/cookies.ts
@@ -1,4 +1,5 @@
 import { serialize, parse } from 'cookie'
+import { IncomingMessage } from 'http'
 import { NextApiResponse } from 'next'
 import { RequestWithCookies } from './session'
 
@@ -6,7 +7,14 @@ export const TOKEN_NAME = 'squeak_session'
 
 export const MAX_AGE = 86400 * 30 // 30 days
 
+function cookieDomainFromOrigin(req: IncomingMessage) {
+    const origin = req.headers.origin || 'squeak.cloud'
+    return origin.replace(/^https?:\/\//, '').replace(/\:\d+$/, '')
+}
+
 export function setTokenCookie(res: NextApiResponse, token: string) {
+    const domain = cookieDomainFromOrigin(res.req)
+
     const cookie = serialize(TOKEN_NAME, token, {
         maxAge: MAX_AGE,
         expires: new Date(Date.now() + MAX_AGE * 1000),
@@ -14,6 +22,7 @@ export function setTokenCookie(res: NextApiResponse, token: string) {
         secure: process.env.NODE_ENV === 'production',
         path: '/',
         sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+        domain: domain,
     })
 
     res.setHeader('Set-Cookie', cookie)

--- a/lib/auth/cookies.ts
+++ b/lib/auth/cookies.ts
@@ -13,7 +13,7 @@ export function setTokenCookie(res: NextApiResponse, token: string) {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
         path: '/',
-        sameSite: 'none',
+        sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
     })
 
     res.setHeader('Set-Cookie', cookie)

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -31,7 +31,7 @@ const defaultEmailConfig: ValidEmailConfig = {
     mailgun_domain: 'mail.squeak.cloud',
     mailgun_from_email: 'noreply@squeak.cloud',
     mailgun_from_name: 'PostHog',
-    company_domain: 'squeak.cloud',
+    company_domain: 'https://squeak.cloud',
     company_name: 'Squeak',
 }
 
@@ -71,8 +71,16 @@ export async function sendEmail(organizationId: string, to: string, template: Em
     )
 }
 
+function formatCompanyDomain(domain: string) {
+    if (domain.startsWith('http://') || domain.startsWith('https://')) {
+        return domain
+    }
+
+    return `https://${domain}`
+}
+
 function mailgunSendOptions(templateOptions: EmailTemplateOptions, config: SqueakEmailConfig) {
-    const url = new URL(config.company_domain)
+    const url = new URL(formatCompanyDomain(config.company_domain))
 
     const fromName = config.mailgun_from_name || config.company_name
     const fromDomain = config.mailgun_from_email || `noreply@${url.hostname}`

--- a/pages/api/logout.ts
+++ b/pages/api/logout.ts
@@ -1,15 +1,11 @@
 import { NextApiRequest, NextApiResponse } from 'next'
+import nc from 'next-connect'
 
 import { removeTokenCookie } from '../../lib/auth/cookies'
-import { allowedOrigin, corsMiddleware } from '../../lib/middleware'
-import nc from 'next-connect'
+import { corsMiddleware } from '../../lib/middleware'
 import { clearOrganization } from '../../util/getActiveOrganization'
 
-const handler = nc<NextApiRequest, NextApiResponse>()
-    .use(corsMiddleware)
-    .use(allowedOrigin)
-    .post(doLogout)
-    .get(doLogout)
+const handler = nc<NextApiRequest, NextApiResponse>().use(corsMiddleware).post(doLogout).get(doLogout)
 
 // POST /api/logout
 async function doLogout(req: NextApiRequest, res: NextApiResponse) {


### PR DESCRIPTION
This PR includes three changes:

1. It removes the `allowedOrigin` middleware from the `/api/logout` endpoint, which checks for the presence of a `organizationId` param, which we don't need for this endpoint
2. It fixes a bug with the forgot password endpoint to differentiate b/w sdk clients and internal (squeak.cloud) clients, using a default email config for squeak.cloud client requests
3. Sets the cookie domain to the origin of the requesting site. For example, sessions that originate on posthog.com will not carry over to squeak.cloud cc @corywatilo 