### PR TITLE
Don't explicitly set the cookie domain

### DIFF
--- a/hooks/useActiveOrganization.ts
+++ b/hooks/useActiveOrganization.ts
@@ -6,7 +6,7 @@ const SQUEAK_ORG_ID_COOKIE_KEY = 'squeak_organization_id'
 const useActiveOrganization = () => {
     const setActiveOrganization = async (userId: string, organizationId?: string) => {
         if (organizationId) {
-            setCookie(null, SQUEAK_ORG_ID_COOKIE_KEY, `${organizationId}`, { path: '/' })
+            setCookie(null, SQUEAK_ORG_ID_COOKIE_KEY, `${organizationId}`, { path: '/', sameSite: 'none' })
             return
         }
 
@@ -20,7 +20,7 @@ const useActiveOrganization = () => {
         // get the first organization
         const [organization] = organizations
 
-        setCookie(null, SQUEAK_ORG_ID_COOKIE_KEY, `${organization.organization_id}`, { path: '/' })
+        setCookie(null, SQUEAK_ORG_ID_COOKIE_KEY, `${organization.organization_id}`, { path: '/', sameSite: 'none' })
     }
 
     const getActiveOrganization = (): string => {

--- a/lib/auth/cookies.ts
+++ b/lib/auth/cookies.ts
@@ -1,5 +1,4 @@
 import { serialize, parse } from 'cookie'
-import { IncomingMessage } from 'http'
 import { NextApiResponse } from 'next'
 import { RequestWithCookies } from './session'
 
@@ -7,14 +6,7 @@ export const TOKEN_NAME = 'squeak_session'
 
 export const MAX_AGE = 86400 * 30 // 30 days
 
-function cookieDomainFromOrigin(req: IncomingMessage) {
-    const origin = req.headers.origin || 'squeak.cloud'
-    return origin.replace(/^https?:\/\//, '').replace(/\:\d+$/, '')
-}
-
 export function setTokenCookie(res: NextApiResponse, token: string) {
-    const domain = cookieDomainFromOrigin(res.req)
-
     const cookie = serialize(TOKEN_NAME, token, {
         maxAge: MAX_AGE,
         expires: new Date(Date.now() + MAX_AGE * 1000),
@@ -22,7 +14,6 @@ export function setTokenCookie(res: NextApiResponse, token: string) {
         secure: process.env.NODE_ENV === 'production',
         path: '/',
         sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
-        domain: domain,
     })
 
     res.setHeader('Set-Cookie', cookie)


### PR DESCRIPTION
This was causing issues bc it was trying to set the cookie domain to something
other than the domain on which the API is hosted, which browsers don't allow.