### PR TITLE
set sameSite, httpOnly and secure cookie options on logout

### DIFF
--- a/lib/auth/cookies.ts
+++ b/lib/auth/cookies.ts
@@ -23,6 +23,9 @@ export function removeTokenCookie(res: NextApiResponse) {
     const cookie = serialize(TOKEN_NAME, '', {
         maxAge: -1,
         path: '/',
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
     })
 
     res.setHeader('Set-Cookie', cookie)


### PR DESCRIPTION
This was causing issues with cross-site logout requests (e.g. when trying to logout from squeak-react). If you don't explicitly set the `sameSite` option to `none`, the browser defaults it to `lax`, and the browser will refuse to set those cookies on cross-site requests. So this essentially just sets the same cookie options that we do when we generate the login cookie so we don't hit these errors.

<img width="844" alt="CleanShot 2022-08-18 at 10 17 52@2x" src="https://user-images.githubusercontent.com/12774/185455847-c460ca58-91b6-4dbb-953f-9d877e9788cc.png">
