### PR TITLE
github actions step to auto deploy app after docker push

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -23,3 +23,9 @@ jobs:
               with:
                   push: true
                   tags: posthog/squeak:latest
+            - name: Deploy app
+              env:
+                DO_API_TOKEN: ${{ secrets.DO_API_TOKEN }}
+                DO_APP_ID: ${{ secrets.DO_APP_ID }}
+              run: |
+                curl -X POST -H "Authorization: Bearer $DO_API_TOKEN" https://api.digitalocean.com/v2/apps/$DO_APP_ID/deployments


### PR DESCRIPTION
This allows auto-deploying a digital ocean app after the image is pushed. Two secrets need to be set to enable:
1. `DO_API_TOKEN` - an api token that can be generated from the digital ocean dashboard
2. `DO_APP_ID` - the uuid of the app we want to deploy