### PR TITLE
Organization ID fixes

### DIFF
--- a/hooks/useActiveOrganization.ts
+++ b/hooks/useActiveOrganization.ts
@@ -1,7 +1,7 @@
 import { parseCookies, setCookie } from 'nookies'
 import { getUserOrganizations } from '../lib/api/'
 
-const SQUEAK_ORG_ID_COOKIE_KEY = 'squeak_organization_id'
+export const SQUEAK_ORG_ID_COOKIE_KEY = 'squeak_organization_id'
 
 const useActiveOrganization = () => {
     const setActiveOrganization = async (userId: string, organizationId?: string) => {

--- a/lib/api/apiUtils.ts
+++ b/lib/api/apiUtils.ts
@@ -108,3 +108,12 @@ export function safeJson(res: NextApiResponse, data: unknown, statusCode?: numbe
         .setHeader('Content-Type', 'application/json')
         .send(json)
 }
+
+const API_DOMAIN = process.env.NODE_ENV === 'production' ? process.env.API_DOMAIN : 'http://localhost:3000'
+
+// This is not foolproof, as the origin header is a user-provided header, but this should work for now
+// In prod, https://squeak.cloud is the api domain, so all others will be considered SDK requests
+export function isSDKRequest(req: NextApiRequest) {
+    const origin = req.headers.origin
+    return origin !== API_DOMAIN
+}

--- a/lib/auth/cookies.ts
+++ b/lib/auth/cookies.ts
@@ -1,5 +1,7 @@
 import { serialize, parse } from 'cookie'
 import { NextApiResponse } from 'next'
+import { setCookie } from 'nookies'
+import { SQUEAK_ORG_ID_COOKIE_KEY } from '../../hooks/useActiveOrganization'
 import { RequestWithCookies } from './session'
 
 export const TOKEN_NAME = 'squeak_session'
@@ -42,4 +44,10 @@ export function parseCookies(req: RequestWithCookies) {
 export function getTokenCookie(req: RequestWithCookies) {
     const cookies = parseCookies(req)
     return cookies[TOKEN_NAME]
+}
+
+// TODO: Move this to a iron-sealed cookie, or store in the session cookie
+export function setOrgIdCookie(res: NextApiResponse, orgId: string) {
+    if (!orgId) throw new Error('Cannot set empty org id')
+    setCookie({ res }, SQUEAK_ORG_ID_COOKIE_KEY, orgId, { path: '/' })
 }

--- a/pages/api/user-setup.ts
+++ b/pages/api/user-setup.ts
@@ -9,7 +9,7 @@ import trackUserSignup from '../../util/posthog/trackUserSignup'
 import trackOrganizationSignup from '../../util/posthog/trackOrganizationSignup'
 import { SqueakConfig } from '@prisma/client'
 
-import { getSessionUser } from '../../lib/auth'
+import { getSessionUser, setOrgIdCookie } from '../../lib/auth'
 import { sendUserConfirmation } from '../../lib/email'
 import { getConfirmationToken } from '../../db'
 
@@ -127,6 +127,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         organizationName,
     }
 
+    // Set the org cookie in the session
+    setOrgIdCookie(res, organization.id)
     res.status(200).json(response)
 
     const confirmationToken = await getConfirmationToken(user)


### PR DESCRIPTION
This PR fixes a few issues:
* Ensures in the `withAdminAccess` hook that an `organizationId` be set. We try to set a default here in the case that it's not, otherwise we raise an error
* Sets the org id cookie on login and signup
* In the login context, we differentiate how we set the orgId based on whether the request is a squeak.cloud login or an sdk login