### PR TITLE
Turn the sentry traces sample rate way down

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -9,7 +9,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
 Sentry.init({
     dsn: SENTRY_DSN,
     // Adjust this value in production, or use tracesSampler for greater control
-    tracesSampleRate: 0.3,
+    tracesSampleRate: 0.0001  // 0.001%
     // ...
     // Note: if you want to override the automatic release value, do not set a
     // `release` value here - use the environment variable `SENTRY_RELEASE`, so

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -9,7 +9,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
 Sentry.init({
     dsn: SENTRY_DSN,
     // Adjust this value in production, or use tracesSampler for greater control
-    tracesSampleRate: 0.3,
+    tracesSampleRate: 0.0001  // 0.001%
     // ...
     // Note: if you want to override the automatic release value, do not set a
     // `release` value here - use the environment variable `SENTRY_RELEASE`, so


### PR DESCRIPTION
Squeak used 50% of our monthly allocation of free traces in 1 week. That's way too many