### PR TITLE
Allow organization ID to be passed in body or query param

### DIFF
--- a/src/pages/api/roadmap/index.tsx
+++ b/src/pages/api/roadmap/index.tsx
@@ -25,7 +25,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 
 async function handleGet(req: NextApiRequest, res: NextApiResponse) {
-    const organizationId = getActiveOrganization({ req, res })
+    const organizationId = req.body.organizationId || req.query.organizationId || getActiveOrganization({ req, res })
     if (!organizationId) return orgIdNotFound(res)
 
     const roadmap = await prisma.roadmap.findMany({


### PR DESCRIPTION
- Allow organization ID to be passed in body or query param on roadmap endpoint