### PR TITLE
Fetch Gravatar on each profile update

### DIFF
--- a/packages/squeak/package.json
+++ b/packages/squeak/package.json
@@ -39,6 +39,7 @@
         "form-data": "^4.0.0",
         "formidable": "^2.0.1",
         "formik": "^2.2.9",
+        "gravatar": "^1.8.2",
         "jsonwebtoken": "^8.5.1",
         "lodash.debounce": "^4.0.8",
         "lodash.groupby": "^4.6.0",

--- a/packages/squeak/src/pages/api/profiles/[id].ts
+++ b/packages/squeak/src/pages/api/profiles/[id].ts
@@ -3,7 +3,7 @@ import { getSessionUser } from 'src/lib/auth'
 import { requireOrgAdmin, safeJson } from '../../../lib/api/apiUtils'
 import prisma from '../../../lib/db'
 import nc from 'next-connect'
-
+import getGravatar from 'gravatar'
 import { allowedOrigin, corsMiddleware, validateBody } from '../../../lib/middleware'
 
 const handler = nc<NextApiRequest, NextApiResponse>()
@@ -72,10 +72,12 @@ async function handlePatch(req: NextApiRequest, res: NextApiResponse) {
         const params: UpdateProfilePayload = req.body
         if (!params || Object.keys(params).some((param) => !allowed.includes(param))) return res.status(500)
         const { teamId, ...other } = params
-
+        const gravatar = getGravatar.url(session?.email || '')
+        const avatar = await fetch(`https:${gravatar}?d=404`).then((res) => (res.ok && `https:${gravatar}`) || null)
         const data = {
             ...(teamId ? { team_id: teamId === 'None' ? null : parseInt(teamId) } : {}),
             ...other,
+            avatar,
         }
 
         const profile = await prisma.profile.update({


### PR DESCRIPTION
Currently if a user creates an account and does not have a Gravatar, their avatar field is left as null forever. This PR checks for a new Gravatar each time they update their profile.