### PR TITLE
Update correct profile on /api/profiles/[id]

### DIFF
--- a/packages/squeak/src/pages/api/profiles/[id].ts
+++ b/packages/squeak/src/pages/api/profiles/[id].ts
@@ -81,7 +81,7 @@ async function handlePatch(req: NextApiRequest, res: NextApiResponse) {
         }
 
         const profile = await prisma.profile.update({
-            where: { id: session.profileId },
+            where: { id: profileId },
             data,
         })
 


### PR DESCRIPTION
- Updates the profile based on the ID in the query not the session