### PR TITLE
Save subject and question between page loads

### DIFF
--- a/packages/squeak-react/src/components/QuestionForm.tsx
+++ b/packages/squeak-react/src/components/QuestionForm.tsx
@@ -1,5 +1,5 @@
 import { Field, Form, Formik } from 'formik'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { useOrg } from '../hooks/useOrg'
 import { useUser } from '../hooks/useUser'
@@ -133,7 +133,7 @@ export default function QuestionForm({
 }: QuestionFormProps) {
   const { organizationId, apiHost, profileLink } = useOrg()
   const { user, setUser } = useUser()
-  const [formValues, setFormValues] = useState(null)
+  const [formValues, setFormValues] = useState<any>(null)
   const [view, setView] = useState<string | null>(initialView || null)
   const [loading, setLoading] = useState(false)
   const buttonText =
@@ -204,6 +204,13 @@ export default function QuestionForm({
       setView(view)
       setFormValues(null)
     } else {
+      localStorage.setItem(
+        'squeak-initial-values',
+        JSON.stringify({
+          question: values?.question,
+          subject: values?.subject
+        })
+      )
       setFormValues(values)
       setView('auth')
       setLoading(false)
@@ -213,8 +220,25 @@ export default function QuestionForm({
   const doLogout = async () => {
     // @ts-ignore
     await post(apiHost, '/api/logout')
+    localStorage.removeItem('squeak-initial-values')
     setUser(null)
   }
+
+  useEffect(() => {
+    try {
+      const initialValues = JSON.parse(
+        localStorage.getItem('squeak-initial-values') || ''
+      )
+      const subject = initialValues?.subject
+      const question = initialValues?.question
+      if (initialValues && (subject || question)) {
+        setFormValues({ subject, question })
+      }
+    } catch (e) {
+      console.error(e)
+      return
+    }
+  }, [])
 
   return view ? (
     {


### PR DESCRIPTION
- Saves subject and question in local storage after "Login & post" is clicked. If the page is refreshed, the question and subject saved in local storage are used as initial values on the form
- Removes the local storage item when the user logs out